### PR TITLE
Updated supported operating systems

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -37,3 +37,8 @@ releases:
       minor_changes:
         - Updated incorrect path in documentation and unit test.
     release_date: "2023-10-01"
+  1.1.2:
+    changes:
+      minor_changes:
+        - Debian Bookworm and Ubuntu Lunar added to supported versions.
+    release_date: "2023-11-01"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: bec
 name: shell
 
-version: 1.1.1
+version: 1.1.2
 readme: README.md
 authors:
   - Patrick Becker <galaxy@thinkbox.center>

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,14 +4,16 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: ubuntu-20.04
-    image: ubuntu:20.04
+  - name: ubuntu-23.04
+    image: ubuntu:23.04
   - name: ubuntu-22.04
     image: ubuntu:22.04
+  - name: ubuntu-20.04
+    image: ubuntu:20.04
+  - name: debian-12
+    image: debian:12
   - name: debian-11
     image: debian:11
-  - name: debian-10
-    image: debian:10
 provisioner:
   name: ansible
   inventory:

--- a/roles/zsh/meta/main.yml
+++ b/roles/zsh/meta/main.yml
@@ -9,10 +9,11 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
+        - bookworm
         - bullseye
-        - buster
     - name: Ubuntu
       versions:
+        - lunar
         - jammy
         - focal
 

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -12,10 +12,10 @@
       - zsh_system_config is defined
 
 - name: Ensure zsh with dependencies are installed
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name: "{{ ['zsh'] + zsh_dependencies }}"
     state: present
-    update_cache: true
+    update_cache: true  # Unknown arguments will be passed to the underlying package module.
   become: true
   tags:
     - zsh


### PR DESCRIPTION
Updated the list of supported operating systems and replaced `ansible.builtin.apt` with the generic `ansible.builtin.package` module.

Added:
- Debian Bookworm
- Ubuntu Lunar

Removed:
- Debian Buster